### PR TITLE
fix: correct KSH_ARRAYS array slice in _em_delete_line_at

### DIFF
--- a/em.zsh
+++ b/em.zsh
@@ -231,7 +231,7 @@ em() {
         for ((i = pos; i < last; i++)); do
             _em_lines[i]="${_em_lines[i+1]}"
         done
-        _em_lines=("${_em_lines[@]:0:last}")
+        _em_lines=("${_em_lines[@]:0:$last}")
     }
 
     _em_delete_lines_at() {


### PR DESCRIPTION
## Problem

With `setopt KSH_ARRAYS` active, zsh treats bare variable names inside
`${array[@]:offset:length}` as parameter modifier strings, not arithmetic
expressions. This causes the error reported in #6:

```
_em_delete_line_at:8: unrecognized modifier `l'
```

The affected line was:
```zsh
_em_lines=("${_em_lines[@]:0:last}")
```

## Fix

Add the `$` prefix so zsh evaluates `last` as a variable reference:

```zsh
_em_lines=("${_em_lines[@]:0:$last}")
```

This is a one-character fix. No other files contain the same pattern.

Fixes #6